### PR TITLE
Use deployment api to find completed time

### DIFF
--- a/config.html
+++ b/config.html
@@ -30,13 +30,13 @@
 
     <fieldset class="radio" id="measurement-options-fieldset">
       <legend>Measurement Unit</legend>
-      <input name="measurement-options" type="radio" id="days" value="days" checked="true">
+      <input name="measurement-options" type="radio" id="days" value="days" name="radio" checked>
       <label for="days">days</label>
       <br/>
-      <input name="measurement-options" type="radio" id="hours" value="hours" checked="false">
+      <input name="measurement-options" type="radio" id="hours" value="hours" name="radio">
       <label for="hours">hours</label>
       <br/>
-      <input name="measurement-options" type="radio" id="weeks" value="weeks" checked="false">
+      <input name="measurement-options" type="radio" id="weeks" value="weeks" name="radio">
       <label for="weeks">weeks</label>
       <br/>
     </fieldset>

--- a/config.html
+++ b/config.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="dropdown">
-      <label>Release Definition</label>
+      <label>Release Environment</label>
       <div class="wrapper">
         <select id="release-environment-dropdown">
         </select>
@@ -30,13 +30,13 @@
 
     <fieldset class="radio" id="measurement-options-fieldset">
       <legend>Measurement Unit</legend>
-      <input name="measurement-options" type="radio" id="days" value="days" name="radio" checked="true">
+      <input name="measurement-options" type="radio" id="days" value="days" checked="true">
       <label for="days">days</label>
       <br/>
-      <input name="measurement-options" type="radio" id="hours" value="hours" name="radio" checked="false">
+      <input name="measurement-options" type="radio" id="hours" value="hours" checked="false">
       <label for="hours">hours</label>
       <br/>
-      <input name="measurement-options" type="radio" id="weeks" value="weeks" name="radio" checked="false">
+      <input name="measurement-options" type="radio" id="weeks" value="weeks" checked="false">
       <label for="weeks">weeks</label>
       <br/>
     </fieldset>

--- a/config.js
+++ b/config.js
@@ -155,7 +155,7 @@ VSS.require("TFS/Dashboards/WidgetHelpers", function(WidgetHelpers) {
                   .map(e => getOptionHtmlForEnvironment(e))
                   .join(emptyString);
 
-                releaseEnvironmentSelector.append(markupToInsert);
+                releaseEnvironmentSelector.html(markupToInsert);
 
                 registerChangeHandler(
                   releaseEnvironmentSelector,

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <body>
   <div class="widget">
     <h2 class="title"></h2>
-    <div id="data" class="big-count"></div>
+    <div id="data" class="big-count" style="color:black;"></div>
     <div id="label"></div>
   </div>
 </body>

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ VSS.require("TFS/Dashboards/WidgetHelpers", function(WidgetHelpers) {
       labelElement.text(`${measurmentUnit} since last release`);
 
       release
-        .getLatestReleaseForEnvironment(
+        .getLatestDeploymentForEnvironment(
           releaseDefinitionId,
           releaseEnvironmentId,
           sourceBranchFilter
@@ -64,7 +64,7 @@ VSS.require("TFS/Dashboards/WidgetHelpers", function(WidgetHelpers) {
             let result = null;
 
             try {
-              let lastReleaseTime = moment(r.modifiedOn);
+              let lastReleaseTime = moment(r ? r.completedOn : 0);
               let now = moment();
 
               result = now.diff(lastReleaseTime, measurmentUnit);

--- a/index.js
+++ b/index.js
@@ -79,6 +79,21 @@ VSS.require("TFS/Dashboards/WidgetHelpers", function(WidgetHelpers) {
           let data = $("#data");
           data.text(difference);
 
+          try {
+            let releaseLink = r.release._links.web.href;
+            if (releaseLink) {
+              data.wrap(() => {
+                let link = $("<a/>");
+                link.attr("href", releaseLink);
+                link.attr("target", "_blank");
+                link.text($(this).text());
+                return link;
+              });
+            }
+          } catch (e) {
+            console.warn("Caught:", e);
+          }
+
           // color the widget according to the health
           let cellColor = "red";
           if (difference === null) {

--- a/lib/release.js
+++ b/lib/release.js
@@ -9,7 +9,7 @@ export class Release {
     function getBaseReleasesApi() {
       return `https://${context.collection.name}.vsrm.visualstudio.com/${
         context.project.name
-      }/_apis/Release`;
+        }/_apis/Release`;
     }
 
     function getReleasesApi() {
@@ -26,7 +26,7 @@ export class Release {
 
     function getAuthHeader() {
       return new Promise((resolve, reject) => {
-        VSS.require(["VSS/Authentication/Services"], function(
+        VSS.require(["VSS/Authentication/Services"], function (
           VSS_Auth_Service
         ) {
           VSS.getAccessToken().then(token => {
@@ -114,7 +114,7 @@ export class Release {
     ) => {
       let api =
         getDeploymentsApi() +
-        `?definitionId=${definitionId}&definitionEnvironmentId=${environmentId}&deploymentStatus=succeeded&queryOrder=descending`;
+        `?definitionId=${definitionId}&definitionEnvironmentId=${environmentId}&deploymentStatus=succeeded&queryOrder=descending&$top=1`;
 
       // VSTS expects the "full" ref name, meaning it starts with refs/heads/ followed
       // by the branch name as most folks know it. We'll handle that detail here,

--- a/lib/release.js
+++ b/lib/release.js
@@ -20,6 +20,10 @@ export class Release {
       return getBaseReleasesApi() + "/definitions";
     }
 
+    function getDeploymentsApi() {
+      return getBaseReleasesApi() + "/deployments";
+    }
+
     function getAuthHeader() {
       return new Promise((resolve, reject) => {
         VSS.require(["VSS/Authentication/Services"], function(
@@ -99,6 +103,32 @@ export class Release {
           return Promise.reject("malformed response:", result);
         } else {
           return Promise.resolve(result.value[0]);
+        }
+      });
+    };
+
+    this.getLatestDeploymentForEnvironment = (
+      definitionId,
+      environmentId,
+      sourceBranchFilter
+    ) => {
+      let api =
+        getDeploymentsApi() +
+        `?definitionId=${definitionId}&definitionEnvironmentId=${environmentId}&deploymentStatus=succeeded&queryOrder=descending`;
+
+      // VSTS expects the "full" ref name, meaning it starts with refs/heads/ followed
+      // by the branch name as most folks know it. We'll handle that detail here,
+      // it's not worth imposing it on the user.
+      if (sourceBranchFilter && sourceBranchFilter !== "") {
+        api = api + `&sourceBranchFilter=refs/heads/${sourceBranchFilter}`;
+      }
+
+      return authenticatedGet(api).then(result => {
+        console.log("result:", result);
+        if (!result || !result.count === 1) {
+          return Promise.reject("malformed response:", result);
+        } else {
+          return Promise.resolve(result.value[0] || null);
         }
       });
     };

--- a/lib/release.js
+++ b/lib/release.js
@@ -9,7 +9,7 @@ export class Release {
     function getBaseReleasesApi() {
       return `https://${context.collection.name}.vsrm.visualstudio.com/${
         context.project.name
-        }/_apis/Release`;
+      }/_apis/Release`;
     }
 
     function getReleasesApi() {
@@ -26,7 +26,7 @@ export class Release {
 
     function getAuthHeader() {
       return new Promise((resolve, reject) => {
-        VSS.require(["VSS/Authentication/Services"], function (
+        VSS.require(["VSS/Authentication/Services"], function(
           VSS_Auth_Service
         ) {
           VSS.getAccessToken().then(token => {
@@ -128,7 +128,7 @@ export class Release {
         if (!result || !result.count === 1) {
           return Promise.reject("malformed response:", result);
         } else {
-          return Promise.resolve(result.value[0] || null);
+          return Promise.resolve(result.value.pop() || null);
         }
       });
     };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "vsts-widget-time-since-release",
   "version": "0.1.0-beta",
-  "description": "Simple widget to place on a VSTS Dashboard to show how long it has been since your team released code.",
+  "description":
+    "Simple widget to place on a VSTS Dashboard to show how long it has been since your team released code.",
   "main": "index.js",
   "repository": "https://github.com/zumwald/vsts-widget-time-since-release.git",
   "author": "Dan Zumwalt <daniel.zumwalt@outlook.com>",
@@ -14,12 +15,10 @@
     "precommit": "lint-staged",
     "prettier": "prettier --write *.{js,json,md}",
     "build": "webpack && cd ./dist && tfx extension create",
-    "watch": "yarn run build -- --watch"
+    "watch": "yarn run build --watch"
   },
   "lint-staged": {
-    "*.{js,json,md}": [
-      "prettier -l"
-    ]
+    "*.{js,json,md}": ["prettier -l"]
   },
   "dependencies": {
     "moment": "^2.20.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "precommit": "lint-staged",
     "prettier": "prettier --write *.{js,json,md}",
     "build": "webpack && cd ./dist && tfx extension create",
+    "publish": "webpack && cd ./dist && tfx extension publish",
     "watch": "yarn run build --watch"
   },
   "lint-staged": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "vsts-widget-time-since-release",
-  "version": "1.1.9",
+  "version": "1.1.12",
   "name":
     "Simple widget to place on a VSTS Dashboard to show how long it has been since your team released code.",
   "publisher": "teamsengsys",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,10 +1,10 @@
 {
   "manifestVersion": 1,
   "id": "vsts-widget-time-since-release",
-  "version": "1.1.0",
+  "version": "1.1.9",
   "name":
     "Simple widget to place on a VSTS Dashboard to show how long it has been since your team released code.",
-  "publisher": "danzumwalt",
+  "publisher": "teamsengsys",
   "targets": [
     {
       "id": "Microsoft.VisualStudio.Services"
@@ -17,7 +17,7 @@
       "type": "ms.vss-dashboards-web.widget",
       "targets": [
         "ms.vss-dashboards-web.widget-catalog",
-        "danzumwalt.vsts-widget-time-since-release.vsts-widget-time-since-release-configuration"
+        "teamsengsys.vsts-widget-time-since-release.vsts-widget-time-since-release-configuration"
       ],
       "properties": {
         "name": "Time Since Release",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "vsts-widget-time-since-release",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "name":
     "Simple widget to place on a VSTS Dashboard to show how long it has been since your team released code.",
   "publisher": "danzumwalt",


### PR DESCRIPTION
modifiedOn date does not change on the completion of a deployment. This means the time this widget is looking at is actually just the started time. This uses the VSTS deployments API to find the completed time of the most recent deployment for the relese/environment pair.